### PR TITLE
feat: Enhance "Books Loaded" tab with visual comic covers

### DIFF
--- a/code/kthoom.css
+++ b/code/kthoom.css
@@ -389,7 +389,7 @@ button:focus {
 /** Reading Stack */
 
 #readingStack {
-  margin-left: -21em;
+  margin-left: -61em;
   left: 0px;
 }
 
@@ -414,7 +414,7 @@ button:focus {
 }
 
 #readingStackContents {
-  width: 20em;
+  width: 60em;
 }
 
 #readingStack.opened {
@@ -562,4 +562,26 @@ button:focus {
 
 .hideEnableDirectoryElem {
   display: none;
+}
+
+.readingStackCovers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.readingStackBook img {
+  width: 150px;
+  height: 200px;
+  object-fit: cover;
+}
+
+.readingStackBook p {
+  margin: 0;
+  text-align: center;
+  white-space: normal;
+}
+
+.readingStackBook button {
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
This commit transforms the "Books Loaded" tab from a text-based list into a visually-driven interface.

- Increases the tab size to three times its current size when opened.
- Displays the visual cover of the first issue for each comic book collection.
- Implements an interaction flow where clicking a collection cover displays all the individual comic book issues belonging to that collection.
- Clicking a specific comic issue loads and displays the selected comic in the main viewing area.
- Handles single books that are not part of a collection.