### PR TITLE
feat: Auto-saving PWA with offline storage and delete functionality

### DIFF
--- a/code/database.js
+++ b/code/database.js
@@ -91,6 +91,16 @@ class Database {
       request.onerror = (event) => reject(event.target.error);
     });
   }
+
+  deleteAllBooks() {
+    return new Promise((resolve, reject) => {
+      const transaction = this.db_.transaction([BOOK_STORE_NAME], 'readwrite');
+      const store = transaction.objectStore(BOOK_STORE_NAME);
+      const request = store.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = (event) => reject(event.target.error);
+    });
+  }
 }
 
 export const db = new Database();

--- a/code/kthoom.css
+++ b/code/kthoom.css
@@ -3,6 +3,21 @@
   width: 7px;
 }
 
+.readingStackBook .deleteBookButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: red;
+  color: white;
+  border: none;
+  border-radius: 0 0 0 5px;
+  cursor: pointer;
+  font-size: 10px;
+  line-height: 10px;
+  padding: 2px 4px;
+  z-index: 1;
+}
+
 ::-webkit-scrollbar-thumb {
   border-radius: 4px;
   background-color: rgba(0,0,0,.5);

--- a/code/reading-stack.js
+++ b/code/reading-stack.js
@@ -8,6 +8,7 @@
 import { getElem, Params } from './common/helpers.js';
 import { Book, BookContainer } from './book.js';
 import { BookEventType } from './book-events.js';
+import { db } from './database.js';
 
 // TODO: Have the ReadingStack display progress bars in the pane as books load and unarchive.
 
@@ -180,6 +181,19 @@ export class ReadingStack {
         }
         this.renderStack_();
       }
+    }
+  }
+
+  async deleteBook_(book) {
+    const bookName = book.getName();
+    try {
+      await db.deleteBook(bookName);
+      const index = this.books_.indexOf(book);
+      if (index !== -1) {
+        this.removeBook(index);
+      }
+    } catch (err) {
+      console.error(`Could not delete ${bookName} from offline storage.`, err);
     }
   }
 
@@ -450,6 +464,15 @@ export class ReadingStack {
   createCoverDiv_(book, clickHandler) {
     const coverDiv = document.createElement('div');
     coverDiv.className = 'readingStackBook';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.className = 'deleteBookButton';
+    deleteButton.textContent = 'X';
+    deleteButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.deleteBook_(book);
+    });
+    coverDiv.appendChild(deleteButton);
     const img = document.createElement('img');
     const p = document.createElement('p');
     p.textContent = book.getName();

--- a/index.html
+++ b/index.html
@@ -244,21 +244,15 @@
         </button>
       </li>
       <li role="none">
-        <button id="menu-save-offline" style="display:none" class="menuItem"
-                role="menuitem" tabindex="-1" aria-expanded="false">
-          <span class="menuItemText">Save for Offline</span>
-        </button>
-      </li>
-      <li role="none">
-        <button id="menu-delete-offline" style="display:none" class="menuItem"
-                role="menuitem" tabindex="-1" aria-expanded="false">
-          <span class="menuItemText">Delete from Offline</span>
-        </button>
-      </li>
-      <li role="none">
         <button id="menu-close-all" style="display:none" disabled="true" class="menuItem"
                 role="menuitem" tabindex="-1">
           <span class="menuItemText">Close All</span>
+        </button>
+      </li>
+      <li role="none">
+        <button id="menu-delete-all-offline" class="menuItem"
+                role="menuitem" tabindex="-1">
+          <span class="menuItemText">Delete All Offline Books</span>
         </button>
       </li>
       <li role="none">
@@ -315,11 +309,6 @@
         <button id="menu-open-ipfs-hash" class="menuItem" role="menuitem" tabindex="-1">
           <span class="menuItemText">Open from IPFS</span>
           <span class="menuItemKey">I</span>
-        </button>
-      </li>
-      <li role="none">
-        <button id="menu-open-offline" class="menuItem" role="menuitem" tabindex="-1">
-          <span class="menuItemText">Open from Offline</span>
         </button>
       </li>
     </ul>


### PR DESCRIPTION
This commit turns the application into a Progressive Web App (PWA) and adds automatic offline storage for comics, along with options to manage the stored data.

Key changes:
- **PWA:** The application is now a PWA with a service worker for offline caching of app files and an updated web manifest.
- **Auto-saving:** All comics are automatically saved to IndexedDB when they are loaded.
- **Offline Deletion:**
  - A delete button has been added to each book in the reading stack to remove it from both the UI and offline storage.
  - A "Delete All Offline Books" button has been added to the main menu to clear all saved comics from IndexedDB.

This work includes a new `database.js` module for IndexedDB operations, and modifications to `kthoom.js`, `book.js`, and `reading-stack.js` to integrate the new functionality.