### PR TITLE
Fix: Save comics to browser storage for offline use

### DIFF
--- a/code/book.js
+++ b/code/book.js
@@ -163,6 +163,16 @@ export class Book extends EventTarget {
     this.#expectedSize = expectedSize;
 
     // Throw some error if none of #uri, #request, #file, #fileHandle are set?
+
+    if (this.#file || this.#fileHandle) {
+      this.addEventListener(BookEventType.BINDING_COMPLETE, () => {
+        db.saveBook(this).then(() => {
+          console.log(`${this.getName()} has been auto-saved for offline use.`);
+        }).catch(err => {
+          console.error(`Could not auto-save ${this.getName()} for offline use.`, err);
+        });
+      });
+    }
   }
 
   /**

--- a/code/database.js
+++ b/code/database.js
@@ -40,6 +40,9 @@ class Database {
    * @returns {Promise<void>}
    */
   async saveBook(book) {
+    if (!this.db_) {
+      await this.open();
+    }
     const bookName = book.getName();
     const bookData = await book.getArrayBuffer();
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This change fixes the application to correctly save comics to the browser's IndexedDB storage for offline use.

The key changes are:
- The `saveBook` method in `database.js` is now more robust, ensuring the database is open before attempting to save a book.
- An event listener has been added to the `Book` class constructor in `book.js`. For books loaded from a local file, this listener waits for the `BINDING_COMPLETE` event and then saves the book to the database.

This ensures that newly uploaded comics are persisted across sessions, and can be loaded for offline viewing, which was the intended functionality.