### PR TITLE
Fix comic book saving and reloading

### DIFF
--- a/code/book.js
+++ b/code/book.js
@@ -164,15 +164,13 @@ export class Book extends EventTarget {
 
     // Throw some error if none of #uri, #request, #file, #fileHandle are set?
 
-    if (this.#file || this.#fileHandle) {
-      this.addEventListener(BookEventType.BINDING_COMPLETE, () => {
-        db.saveBook(this).then(() => {
-          console.log(`${this.getName()} has been auto-saved for offline use.`);
-        }).catch(err => {
-          console.error(`Could not auto-save ${this.getName()} for offline use.`, err);
-        });
+    this.addEventListener(BookEventType.BINDING_COMPLETE, () => {
+      db.saveBook(this).then(() => {
+        console.log(`${this.getName()} has been auto-saved for offline use.`);
+      }).catch(err => {
+        console.error(`Could not auto-save ${this.getName()} for offline use.`, err);
       });
-    }
+    });
   }
 
   /**

--- a/code/kthoom.js
+++ b/code/kthoom.js
@@ -123,7 +123,7 @@ export class KthoomApp {
     if (bookNames && bookNames.length > 0) {
       const books = [];
       for (const bookName of bookNames) {
-        const book = new Book(bookName, bookName);
+        const book = new Book(bookName);
         books.push(book);
       }
       this.loadMultipleBooks_(books);
@@ -1329,11 +1329,7 @@ export class KthoomApp {
         const book = evt.source;
         this.metadataViewer_.setBook(book);
         if (book === this.currentBook_) {
-          db.saveBook(book).then(() => {
-            console.log(`${book.getName()} has been auto-saved for offline use.`);
-          }).catch(err => {
-            console.error(`Could not auto-save ${book.getName()} for offline use.`, err);
-          });
+          // The book is saved in the Book object's event handler for BINDING_COMPLETE.
         }
         break;
     }


### PR DESCRIPTION
This commit fixes an issue where uploaded comic books were not being saved to the browser's storage and reloaded on subsequent visits.

The saving mechanism has been centralized in the `Book` class. An event listener for `BINDING_COMPLETE` is now unconditionally added to every `Book` object, ensuring that all books are saved to IndexedDB upon successful loading. Redundant saving logic has been removed from `kthoom.js`.

The loading mechanism has been fixed in the `loadSavedBooks_` function in `kthoom.js`. It now correctly instantiates `Book` objects with only the book name, allowing the `book.load()` method to correctly look up the book in the database.