### PR TITLE
Fix comic book persistence

### DIFF
--- a/code/book.js
+++ b/code/book.js
@@ -164,14 +164,6 @@ export class Book extends EventTarget {
 
     // Throw some error if none of #uri, #request, #file, #fileHandle are set?
 
-    this.addEventListener(BookEventType.BINDING_COMPLETE, () => {
-      alert('Attempting to save book: ' + this.getName());
-      db.saveBook(this).then(() => {
-        console.log(`${this.getName()} has been auto-saved for offline use.`);
-      }).catch(err => {
-        console.error(`Could not auto-save ${this.getName()} for offline use.`, err);
-      });
-    });
   }
 
   /**
@@ -187,7 +179,7 @@ export class Book extends EventTarget {
 
   /** @returns {Promise<ArrayBuffer>} */
   getArrayBuffer() {
-    return this.#arrayBuffer;
+    return Promise.resolve(this.#arrayBuffer);
   }
 
   /** @returns {BookContainer} */

--- a/code/database.js
+++ b/code/database.js
@@ -50,11 +50,11 @@ class Database {
       const store = transaction.objectStore(BOOK_STORE_NAME);
       const request = store.put(bookData, bookName);
       request.onsuccess = () => {
-        alert('Successfully saved book: ' + bookName);
+        console.log('Successfully saved book: ' + bookName);
         resolve();
       };
       request.onerror = (event) => {
-        alert('Failed to save book: ' + event.target.error);
+        console.error('Failed to save book: ' + event.target.error);
         reject(event.target.error);
       };
     });

--- a/code/kthoom.js
+++ b/code/kthoom.js
@@ -1104,8 +1104,8 @@ export class KthoomApp {
   }
 
   /** @private */
-  downloadBook_() {
-    const ab = this.currentBook_.getArrayBuffer();
+  async downloadBook_() {
+    const ab = await this.currentBook_.getArrayBuffer();
     if (!ab) {
       alert('Could not download a copy of the book. Sorry!');
       return;
@@ -1332,9 +1332,7 @@ export class KthoomApp {
         /** @type {Book} */
         const book = evt.source;
         this.metadataViewer_.setBook(book);
-        if (book === this.currentBook_) {
-          // The book is saved in the Book object's event handler for BINDING_COMPLETE.
-        }
+        db.saveBook(book);
         break;
     }
   }


### PR DESCRIPTION
This change fixes the issue where comic books were not being saved to the browser's storage and reloaded on subsequent visits.

The saving logic has been refactored to be more robust. The responsibility for saving a book is moved from the Book class to the main KthoomApp class. A book is now saved to the IndexedDB database when its `BINDING_COMPLETE` event is fired.

The loading logic for saved books, which is handled by the `loadSavedBooks_` function, has been verified to be correct.

Additionally, several minor code quality improvements have been made:
- The `getArrayBuffer` method in the Book class now correctly returns a Promise.
- Call sites for `getArrayBuffer` have been updated to handle its asynchronous nature.
- User-facing `alert` calls in the database logic have been replaced with console logs.