### PR TITLE
Fix race condition in ComicBookBinder

### DIFF
--- a/code/comics/comic-book-binder.js
+++ b/code/comics/comic-book-binder.js
@@ -121,9 +121,10 @@ export class ComicBookBinder extends BookBinder {
 
         // Emit a complete event.
         this.dispatchEvent(new BookBindingCompleteEvent(this));
-      });
 
-      this.stop();
+        // Stop the unarchiver only after everything is done.
+        this.stop();
+      });
     });
 
     switch (this.unarchiver.getMIMEType()) {


### PR DESCRIPTION
This change fixes a critical race condition in the `ComicBookBinder` that prevented books, especially larger ones, from being saved correctly.

The `FINISH` event handler for the unarchiver was setting up an asynchronous promise chain to process extracted pages but was then immediately calling `this.stop()`, which terminated the unarchiver's web worker. This premature termination would interrupt the page creation process, meaning the `BookBindingCompleteEvent` was never fired, and the book was never saved to IndexedDB.

The fix moves the `this.stop()` call into the final `.then()` block of the promise chain. This ensures that the unarchiver and its worker are only stopped after all pages have been successfully processed and the `BookBindingCompleteEvent` has been dispatched.

This commit also includes the previous attempts at fixing the issue, which add robustness to the application:
- A `dirty` flag on the `Book` class to correctly track saved states.
- A validation mechanism on startup to detect and delete corrupted entries from IndexedDB.
- Improved book deletion logic to prevent orphaned page data.