### PR TITLE
Fix bug where books were not being saved correctly to local storage.

### DIFF
--- a/code/kthoom.js
+++ b/code/kthoom.js
@@ -15,7 +15,7 @@ import { FitMode } from './book-viewer-types.js';
 import { Menu, MenuEventType } from './menu.js';
 import { ReadingStack } from './reading-stack.js';
 import { Key, Params, assert, getElem, serializeParamsToBrowser } from './common/helpers.js';
-import { ImagePage, WebPShimImagePage } from './page.js';
+import { DatabasePage, ImagePage, WebPShimImagePage } from './page.js';
 import { convertWebPtoJPG, convertWebPtoPNG } from './bitjs/image/webp-shim/webp-shim.js';
 import { MetadataViewer } from './metadata/metadata-viewer.js';
 import { db } from './database.js';
@@ -1360,8 +1360,20 @@ export class KthoomApp {
         // Save all the pages, then save the book metadata.
         const savePromises = [];
         for (let i = 0; i < book.getNumberOfPages(); ++i) {
-          savePromises.push(db.savePage(book.getName(), book.getPage(i)));
+          const page = book.getPage(i);
+
+          // Create an async IIFE to handle the page saving.
+          const savePromise = (async () => {
+            // If we have a DatabasePage that has not been loaded from the DB, we must
+            // load it now so we can save its bytes.
+            if (page instanceof DatabasePage && !page.isInflated()) {
+              await page.inflate();
+            }
+            return db.savePage(book.getName(), page);
+          })();
+          savePromises.push(savePromise);
         }
+
         Promise.all(savePromises)
           .then(() => db.saveBook(book))
           .then(() => {


### PR DESCRIPTION
When a book was loaded from the database, its pages were represented as `DatabasePage` objects. If a save was triggered for this book before a page was viewed, the page's data would not be "inflated" (loaded from the database into memory).

The save mechanism would then attempt to get the bytes for the page, which would return `null`, and this `null` value would overwrite the valid page data in the database.

The fix is to ensure that any `DatabasePage` is inflated before it is saved. This is done by modifying the `handleEvent` method in `kthoom.js` to check for un-inflated `DatabasePage` objects and call `inflate()` on them before passing them to the save function.