### PR TITLE
This commit fixes two critical bugs that prevented the application fr…

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@
 <script>
   window.addEventListener('load', () => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('service-worker.js')
+      navigator.serviceWorker.register('service-worker.js', { type: 'module' })
         .then((registration) => {
           console.log('ServiceWorker registration successful with scope: ', registration.scope);
         })


### PR DESCRIPTION
…om correctly saving books to local storage.

1.  **Fix service worker registration:** The service worker was using ES module `import` statements but was not being registered as a module, causing a `SyntaxError` that prevented it from running. This was fixed by adding `{ type: 'module' }` to the `navigator.serviceWorker.register()` call in `index.html`.

2.  **Fix saving of books from database:** When a book was loaded from the database, its pages were `DatabasePage` objects. If a save was triggered on this book, the application would attempt to save the pages before their data was loaded from the database ("inflated"). This would result in `null` being written to the database, corrupting the saved book. This was fixed by updating the save logic in `kthoom.js` to check for un-inflated `DatabasePage` objects and explicitly call `inflate()` on them before saving.

These two fixes together restore the intended save/load functionality of the application.