### PR TITLE
Fix comic deletion bug on refresh

### DIFF
--- a/code/book.js
+++ b/code/book.js
@@ -496,7 +496,7 @@ export class Book extends EventTarget {
       // Since we are not un-archiving, the book is considered "bound" almost immediately.
       // The pages will load on demand.
       this.#finishedBinding = true;
-      this.dispatchEvent(new BookBindingCompleteEvent(this));
+      // this.dispatchEvent(new BookBindingCompleteEvent(this));
 
       this.#finishedLoading = true;
       this.#dirty = false;

--- a/code/kthoom.js
+++ b/code/kthoom.js
@@ -1378,7 +1378,11 @@ export class KthoomApp {
         // Save all the pages, then save the book metadata.
         const savePromises = [];
         for (let i = 0; i < book.getNumberOfPages(); ++i) {
-          savePromises.push(db.savePage(book.getName(), book.getPage(i)));
+          const page = book.getPage(i);
+          // Only save pages that have actual data.
+          if (page.getBytes()) {
+            savePromises.push(db.savePage(book.getName(), page));
+          }
         }
         Promise.all(savePromises)
           .then(() => db.saveBook(book))


### PR DESCRIPTION
This change fixes a critical bug where uploading a new comic book causes all previously saved comic books to be deleted from the offline database upon application refresh.

The core issue stems from an incorrect event being dispatched when a book is loaded from the database. This triggers a destructive re-save operation that corrupts the stored page data, leading to the book's eventual deletion on the next app load.

This commit addresses the issue by:
1.  Preventing the incorrect `BookBindingCompleteEvent` from being dispatched in `code/book.js` when a book is loaded from the database.
2.  Adding a safeguard in `code/kthoom.js` to ensure that page data exists before attempting to save it.